### PR TITLE
Move dependencies to dependencies.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,11 +35,9 @@ android {
 }
 
 dependencies {
+    implementation coreLibraries
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.5.0'
-    implementation 'com.google.android.material:material:1.6.1'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    testImplementation test
+    androidTestImplementation androidTest
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -8,3 +8,5 @@ plugins {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+apply from: 'buildsystem/dependencies.gradle'

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -1,0 +1,22 @@
+ext {
+    ktxVersion = "1.7.0"
+    appCompatVersion = "1.5.0"
+    materialVersion = "1.6.1"
+    coreLibraries = [
+            "androidx.core:core-ktx:$ktxVersion",
+            "androidx.appcompat:appcompat:$appCompatVersion",
+            "com.google.android.material:material:$materialVersion"
+    ]
+
+    junitVersion = "4.13.2"
+    test = [
+            "junit:junit:$junitVersion"
+    ]
+
+    espresso = "3.4.0"
+    andoidJunitVersion = "1.1.3"
+    androidTest = [
+            "androidx.test.ext:junit:$andoidJunitVersion",
+            "androidx.test.espresso:espresso-core:$espresso"
+    ]
+}


### PR DESCRIPTION
A new file that holds the strings and version for dependencies was created. called `dependencies.gradle`

This file is applied to the main gradle via command `apply from: 'buildsystem/dependencies.gradle'`

Now all dependencies are applied thanks to that file