### PR TITLE
Fixing training list

### DIFF
--- a/app/src/main/java/com/example/stretchy/features/createtraining/ui/CreateTrainingUiState.kt
+++ b/app/src/main/java/com/example/stretchy/features/createtraining/ui/CreateTrainingUiState.kt
@@ -2,13 +2,12 @@ package com.example.stretchy.features.createtraining.ui
 
 import com.example.stretchy.repository.Activity
 
-sealed class CreateTrainingUiState(open val createTrainingButtonVisible: Boolean) {
+sealed class CreateTrainingUiState {
     data class Success(
-        override val createTrainingButtonVisible: Boolean,
         val training: List<Activity>
-    ) : CreateTrainingUiState(createTrainingButtonVisible)
+    ) : CreateTrainingUiState()
 
-    data class Error(val reason: Reason) : CreateTrainingUiState(false) {
+    data class Error(val reason: Reason) : CreateTrainingUiState() {
         sealed class Reason {
             object MissingTrainingName : Reason()
             object NotEnoughExercises : Reason()
@@ -16,9 +15,9 @@ sealed class CreateTrainingUiState(open val createTrainingButtonVisible: Boolean
         }
     }
 
-    object Init : CreateTrainingUiState(false)
+    object Init : CreateTrainingUiState()
 
-    object Done : CreateTrainingUiState(false)
+    object Done : CreateTrainingUiState()
 }
 
 sealed class CreateTrainingActivityItem(

--- a/app/src/main/java/com/example/stretchy/features/createtraining/ui/CreateTrainingViewModel.kt
+++ b/app/src/main/java/com/example/stretchy/features/createtraining/ui/CreateTrainingViewModel.kt
@@ -18,14 +18,17 @@ class CreateTrainingViewModel(val repository: Repository) : ViewModel() {
 
     private var name: String? = null
     private var type: Training.Type = Training.Type.STRETCHING
-    private val currentList = mutableListOf<Activity>()
+    private val trainingExercisesList = mutableListOf<Activity>()
 
     fun addActivity(activityItem: Activity) {
-        currentList.add(activityItem)
+        trainingExercisesList.add(activityItem)
+        val currentList = mutableListOf<Activity>()
+        trainingExercisesList.forEach{ activity ->
+        currentList.add(activity)
+        }
         viewModelScope.launch {
             _uiState.emit(
                 CreateTrainingUiState.Success(
-                    isCreateTrainingButtonVisible(),
                     currentList
                 )
             )
@@ -57,10 +60,6 @@ class CreateTrainingViewModel(val repository: Repository) : ViewModel() {
             }
         }
     }
-
-    private fun isCreateTrainingButtonVisible() =
-        !name.isNullOrBlank() && currentActivitySizeList() >= 1
-
     private fun currentActivitySizeList(): Int =
         (_uiState.value as? CreateTrainingUiState.Success)?.training?.size ?: 0
 
@@ -68,8 +67,8 @@ class CreateTrainingViewModel(val repository: Repository) : ViewModel() {
         viewModelScope.launch {
             val success = (_uiState.value as? CreateTrainingUiState.Success)
             if (success != null) {
-                repository.addTrainingWithActivities(TrainingWithActivity(name!!,TrainingType.STRETCH,true,currentList))
-                currentList.clear()
+                repository.addTrainingWithActivities(TrainingWithActivity(name!!,TrainingType.STRETCH,true,trainingExercisesList))
+                trainingExercisesList.clear()
                 _uiState.emit(CreateTrainingUiState.Done)
             } else {
                 //todo toast

--- a/app/src/main/java/com/example/stretchy/features/createtraining/ui/CreateTrainingViewModel.kt
+++ b/app/src/main/java/com/example/stretchy/features/createtraining/ui/CreateTrainingViewModel.kt
@@ -23,9 +23,7 @@ class CreateTrainingViewModel(val repository: Repository) : ViewModel() {
     fun addActivity(activityItem: Activity) {
         trainingExercisesList.add(activityItem)
         val currentList = mutableListOf<Activity>()
-        trainingExercisesList.forEach{ activity ->
-        currentList.add(activity)
-        }
+        currentList.addAll(trainingExercisesList)
         viewModelScope.launch {
             _uiState.emit(
                 CreateTrainingUiState.Success(
@@ -60,6 +58,7 @@ class CreateTrainingViewModel(val repository: Repository) : ViewModel() {
             }
         }
     }
+
     private fun currentActivitySizeList(): Int =
         (_uiState.value as? CreateTrainingUiState.Success)?.training?.size ?: 0
 
@@ -67,7 +66,14 @@ class CreateTrainingViewModel(val repository: Repository) : ViewModel() {
         viewModelScope.launch {
             val success = (_uiState.value as? CreateTrainingUiState.Success)
             if (success != null) {
-                repository.addTrainingWithActivities(TrainingWithActivity(name!!,TrainingType.STRETCH,true,trainingExercisesList))
+                repository.addTrainingWithActivities(
+                    TrainingWithActivity(
+                        name!!,
+                        TrainingType.STRETCH,
+                        true,
+                        trainingExercisesList
+                    )
+                )
                 trainingExercisesList.clear()
                 _uiState.emit(CreateTrainingUiState.Done)
             } else {

--- a/app/src/main/java/com/example/stretchy/features/createtraining/ui/composable/CreateTrainingComposable.kt
+++ b/app/src/main/java/com/example/stretchy/features/createtraining/ui/composable/CreateTrainingComposable.kt
@@ -66,7 +66,6 @@ fun CreateTrainingComposable(
         Spacer(modifier = Modifier.height(200.dp))
         Box(modifier = Modifier.align(Alignment.BottomCenter)) {
             Button(
-                //   enabled = viewModel.uiState.collectAsState().value.createTrainingButtonVisible,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp),
@@ -110,10 +109,11 @@ private fun ExerciseItem(item: Exercise) {
 
 @Composable
 fun CreateExerciseWidget(viewModel: CreateTrainingViewModel) {
+    val minExerciseDuration = 10
     var visible by remember { mutableStateOf(false) }
     val sliderMaxValue = 300
-    var sliderValue: Int by remember { mutableStateOf(10) }
-    var exerciseDuration: Int by remember { mutableStateOf(10) }
+    var sliderValue: Int by remember { mutableStateOf(minExerciseDuration) }
+    var exerciseDuration: Int by remember { mutableStateOf(minExerciseDuration) }
     var exerciseName = ""
     val context = LocalContext.current
     AnimatedVisibility(visible = !visible) {
@@ -183,6 +183,8 @@ fun CreateExerciseWidget(viewModel: CreateTrainingViewModel) {
                             )
                         )
                         Toast.makeText(context, "Exercise added", Toast.LENGTH_LONG).show()
+                        sliderValue = minExerciseDuration
+                        exerciseDuration = minExerciseDuration
                     } else {
                         Toast.makeText(
                             context,

--- a/app/src/main/java/com/example/stretchy/features/executetraining/ui/data/ExecuteTrainingUiState.kt
+++ b/app/src/main/java/com/example/stretchy/features/executetraining/ui/data/ExecuteTrainingUiState.kt
@@ -5,7 +5,6 @@ sealed class ExecuteTrainingUiState {
     object Error : ExecuteTrainingUiState()
     class TrainingCompleted(val currentTrainingTime: String, val numberOfExercises: Int) :
         ExecuteTrainingUiState()
-
     class Success(val activityItem: ActivityItem) : ExecuteTrainingUiState()
 }
 


### PR DESCRIPTION
`TrainingList shows only 2 elements`, task: https://trello.com/c/M6SBqGUn/5-traininglist-shows-only-2-elements

Fixed bug where only 2 created exercises were shown in the training creation list.
In addition, a small bug was fixed - after creating an exercise, the slider remained in the previous position (i.e. the first exercise had 2 minutes, so when creating the next exercise, the slider was also in the 2-minute position)